### PR TITLE
Enhance GitHub Actions workflows for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - main
+      - hotfix/*
+      - release/*
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/test-act-event-ci.json
+++ b/.github/workflows/test-act-event-ci.json
@@ -1,0 +1,9 @@
+{
+    "event": "workflow_dispatch",
+    "workflow": "publish.yml",
+    "ref": "refs/heads/feature/ci-pipeline-tasks",
+    "inputs": {
+      "version": "0.0.1",
+      "publish_to": "testpypi"
+    }
+  }

--- a/.github/workflows/test-act-event-publish.json
+++ b/.github/workflows/test-act-event-publish.json
@@ -1,0 +1,9 @@
+{
+    "event": "workflow_dispatch",
+    "workflow": "publish.yml",
+    "ref": "refs/heads/feature/ci-pipeline-tasks",
+    "inputs": {
+      "version": "0.0.1",
+      "publish_to": "testpypi"
+    }
+  }


### PR DESCRIPTION
- Add push triggers for main, hotfix, and release branches in publish.yml
- Add test-act-event-ci.json and test-act-event-publish.json for local workflow testing with act