### PR TITLE
Handle empty results in batch geocode responses

### DIFF
--- a/src/geocodio/client.py
+++ b/src/geocodio/client.py
@@ -379,26 +379,25 @@ class Geocodio:
             and response_json["results"]
             and "response" in response_json["results"][0]
         ):
-            results = [
-                GeocodingResult(
-                    address_components=AddressComponents.from_api(
-                        res["response"]["results"][0]["address_components"]
-                    ),
-                    formatted_address=res["response"]["results"][0][
-                        "formatted_address"
-                    ],
-                    location=Location(**res["response"]["results"][0]["location"]),
-                    accuracy=res["response"]["results"][0].get("accuracy", 0.0),
-                    accuracy_type=res["response"]["results"][0].get(
-                        "accuracy_type", ""
-                    ),
-                    source=res["response"]["results"][0].get("source", ""),
-                    fields=self._parse_fields(
-                        res["response"]["results"][0].get("fields")
-                    ),
+            results = []
+            for res in response_json["results"]:
+                response_results = res.get("response", {}).get("results", [])
+                if not response_results:
+                    continue
+                result = response_results[0]
+                results.append(
+                    GeocodingResult(
+                        address_components=AddressComponents.from_api(
+                            result["address_components"]
+                        ),
+                        formatted_address=result["formatted_address"],
+                        location=Location(**result["location"]),
+                        accuracy=result.get("accuracy", 0.0),
+                        accuracy_type=result.get("accuracy_type", ""),
+                        source=result.get("source", ""),
+                        fields=self._parse_fields(result.get("fields")),
+                    )
                 )
-                for res in response_json["results"]
-            ]
             return GeocodingResponse(results=results)
 
         # Handle single response format

--- a/tests/unit/test_geocode.py
+++ b/tests/unit/test_geocode.py
@@ -151,6 +151,63 @@ def test_geocode_batch(client, httpx_mock):
     assert resp.results[1].location.lat == 39.736792
 
 
+def test_geocode_batch_with_invalid_address_result(client, httpx_mock):
+    addresses = [
+        "1109 N Highland St, Arlington VA",
+        "qwertyuiop asdfghjkl zxcvbnm",
+        "1600 Pennsylvania Ave NW, Washington DC",
+    ]
+    valid_result = sample_payload()["results"][0]
+    later_valid_result = {
+        **valid_result,
+        "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC 20500",
+    }
+
+    def batch_response_callback(request):
+        assert request.method == "POST"
+        assert json.loads(request.content) == addresses
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "query": addresses[0],
+                        "response": {"results": [valid_result]},
+                    },
+                    {
+                        "query": addresses[1],
+                        "response": {
+                            "error": "Could not geocode address. No matches found.",
+                            "reference": (
+                                "https://www.geocod.io/geocodio-422-"
+                                "unprocessable-entity/"
+                            ),
+                            "results": [],
+                        },
+                    },
+                    {
+                        "query": addresses[2],
+                        "response": {"results": [later_valid_result]},
+                    },
+                ]
+            },
+        )
+
+    httpx_mock.add_callback(
+        callback=batch_response_callback,
+        url=httpx.URL("https://api.test/v2/geocode"),
+        match_headers={"Authorization": "Bearer TEST_KEY"},
+    )
+
+    resp = client.geocode(addresses)
+
+    assert len(resp.results) == 2
+    assert [result.formatted_address for result in resp.results] == [
+        valid_result["formatted_address"],
+        later_valid_result["formatted_address"],
+    ]
+
+
 def test_geocode_structured_address(client, httpx_mock):
     # Arrange: stub the API call
     structured_address = {


### PR DESCRIPTION
## Summary
- skip batch geocode entries whose nested `response.results` list is empty
- keep parsing later successful entries in the same batch
- add a regression test for mixed valid and invalid address batches

Fixes #24.

## Tests
- `uv run --extra dev pytest tests/unit/test_geocode.py::test_geocode_batch_with_invalid_address_result -q`
- `uv run --extra dev pytest tests/unit -q`
- `uv run --extra dev black --check src/geocodio/client.py tests/unit/test_geocode.py`
- `uv run --extra dev isort --check-only src/geocodio/client.py tests/unit/test_geocode.py`
- `uv run --extra dev flake8 src/ --ignore=E501`
- `python -m compileall -q src/geocodio tests/unit/test_geocode.py`
- `git diff --check`